### PR TITLE
Remove untilBuild version cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [2026.4.0] - 2026-04-11
+
+- Remove untilBuild version cap to support all future IDE versions
+
 ## [2026.2.1] - 2026-02-10
 
 - Restore plugin name to Title Case ("Git Open") per JetBrains naming guidelines

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,6 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = properties("pluginSinceBuild")
-            untilBuild = properties("pluginUntilBuild")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,10 @@ pluginGroup = com.github.iml885203.intellijgitopen
 pluginName = Git Open
 pluginRepositoryUrl = https://github.com/iml885203/IntelliJ-git-open
 # SemVer format -> https://semver.org
-pluginVersion = 2026.2.1
+pluginVersion = 2026.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232
-pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
## Summary
- Remove `pluginUntilBuild` constraint to support all future JetBrains IDE versions (including upcoming 261)
- Bump plugin version to 2026.3.0

## Context
JetBrains notified that the current `until-build = 253.*` will prevent the plugin from being available in IDE version 261.